### PR TITLE
Add go build for windows

### DIFF
--- a/service.go
+++ b/service.go
@@ -51,9 +51,6 @@ func makeAbortChan() chan struct{} {
 
 // Run starts the component server with the given options.
 func Run(opts ...Option) error {
-	//nolint
-	syscall.Umask(000) // allow this process to create files that could be read-write for other processes
-
 	socket, ok := os.LookupEnv(unixSocketPathEnvVar)
 	if !ok {
 		return ErrSocketNotDefined

--- a/socket_unix.go
+++ b/socket_unix.go
@@ -1,0 +1,23 @@
+//go:build unix
+
+/*
+Copyright 2022 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dapr
+
+import "syscall"
+
+func init() {
+	//nolint
+	syscall.Umask(000) // allow this process to create files that could be read-write by others processes
+}


### PR DESCRIPTION
Signed-off-by: Marcos Candeia <marrcooos@gmail.com>

Due to building errors when running on windows machines I've created a socket_unix.go file that builds only when OS is unix

https://github.com/dapr/dapr/actions/runs/3048187369/jobs/4912984388